### PR TITLE
udev: use uaccess tag

### DIFF
--- a/60-hantek-6022-usb.rules
+++ b/60-hantek-6022-usb.rules
@@ -1,3 +1,3 @@
-SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="6022", MODE:="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="6022", MODE:="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="6022", TAGS+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04b5", ATTRS{idProduct}=="6022", TAGS+="uaccess"
 


### PR DESCRIPTION
This makes the device accessible to users which currently have an active session on the machine, which is a bit more secure than just 0666, which is world-writable.
