### PR TITLE
Remove explicit udev reload, udev loads rules automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,10 @@ If you have you have your own examples or have seen this library used, please le
 ## Now with Linux support
 
 If you're on Linux, you're also in luck, as I've provided some reverse engineered binding for libusb to operate this 
-little device. You may wish to first add 60-hantek-6022-usb.rules to your udev rules and reload the rules in udev, via
+little device. You may wish to first add 60-hantek-6022-usb.rules to your udev rules, via
 
      sudo cp 60-hantek-6022-usb.rules /lib/udev/rules.d/
-     sudo udevadm control --reload-rules
- 
+
 After you've done this, the scope should automatically come up with the correct permissions to be accessed without a
 root user.
 


### PR DESCRIPTION
See http://unix.stackexchange.com/a/39485 for reference. I tested this on my machine: I didn’t run the reload command, plugged in the Hantek scope, and the rules file was used.
