### PR TITLE
Remove USBPollerThread, python 2/3 fixes.

### DIFF
--- a/PyHT6022/HantekFirmware/__init__.py
+++ b/PyHT6022/HantekFirmware/__init__.py
@@ -12,7 +12,7 @@ FirmwareControlPacket = namedtuple('FirmwareControlPacket', ['size', 'value', 'd
 def fx2_ihex_to_control_packets(firmware_location):
     packets = list()
     # disable 8051
-    packets.append(FirmwareControlPacket(1, 0xe600, '\x01'))
+    packets.append(FirmwareControlPacket(1, 0xe600, b'\x01'))
     with open(firmware_location, 'r') as f:
         for line in f.readlines():
             line = line.strip()
@@ -34,7 +34,7 @@ def fx2_ihex_to_control_packets(firmware_location):
             else:
                 raise ValueError('Unknown record type 0x{:2x} encountered!'.format(record_type))
     # enable 8051
-    packets.append(FirmwareControlPacket(1, 0xe600, '\x00'))
+    packets.append(FirmwareControlPacket(1, 0xe600, b'\x00'))
     return packets
 
 base_path = os.path.dirname(os.path.realpath(__file__))

--- a/examples/example_linux_continous_read.py
+++ b/examples/example_linux_continous_read.py
@@ -58,7 +58,7 @@ print("Clearing FIFO and starting data transfer...")
 i = 0
 scope.start_capture()
 while time.time() - start_time < 1:
-    time.sleep(0.01)
+    scope.poll()
 scope.stop_capture()
 print("Stopping new transfers.")
 shutdown_event.set()

--- a/examples/example_linux_recordwav.py
+++ b/examples/example_linux_recordwav.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 __author__ = 'Robert Cope', 'Jochen Hoenicke'
 # This code was used to help execute a side-channel attack on the Trezor Bitcoin wallet.
 # See more: http://johoe.mooo.com/trezor-power-analysis/
@@ -28,7 +30,7 @@ print("Setting up scope!")
 
 scope.set_interface(alternative);
 print("ISO" if scope.is_iso else "BULK", "packet size:", scope.packetsize)
-print(scope.set_num_channels(numchannels))
+scope.set_num_channels(numchannels)
 # set voltage range
 scope.set_ch1_voltage_range(voltagerange)
 # set sample rate
@@ -54,7 +56,7 @@ print("Clearing FIFO and starting data transfer...")
 shutdown_event = scope.read_async(extend_callback, blocksize, outstanding_transfers=10,raw=True)
 scope.start_capture()
 while time.time() - start_time < numseconds:
-    time.sleep(0.01)
+    scope.poll()
 print("Stopping new transfers.")
 #scope.stop_capture()
 shutdown_event.set()
@@ -68,14 +70,14 @@ filename = "test.wav"
 print("Writing out data from scope to {}".format(filename))
 with open(filename, "wb") as wf:
     wf.write(b"RIFF")
-    wf.write(pack(b"<L", 44 + total - 8))
+    wf.write(pack("<L", 44 + total - 8))
     wf.write(b"WAVE")
     wf.write(b"fmt \x10\x00\x00\x00\x01\x00\x01\x00")
-    wf.write(pack(b"<L", samplerate))
-    wf.write(pack(b"<L", samplerate))
+    wf.write(pack("<L", samplerate))
+    wf.write(pack("<L", samplerate))
     wf.write(b"\x01\x00\x08\x00")
     wf.write(b"data")
-    wf.write(pack(b"<L", total))
+    wf.write(pack("<L", total))
     for block in data:
         wf.write(block)
 print("Done")


### PR DESCRIPTION
USBPollerThread makes problem with newer linux versions.  Instead
we call poll() instead of sleeping in the example programs.
This should fix #22

Some fixes for Python 2 compatibility.
